### PR TITLE
feature: include guild_id in event handlers

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -19,17 +19,17 @@ pub trait EventHandler {
 
     /// Tymethod called when a track ends. This is useful for then subsequently
     /// playing a new track.
-    fn track_end(&mut self, track: String, reason: String)
+    fn track_end(&mut self, guild_id: u64, track: String, reason: String)
         -> Box<Future<Item = (), Error = ()>>;
 
     /// Tymethod called when an exception occurs during a track playing.
-    fn track_exception(&mut self, track: String, error: String)
+    fn track_exception(&mut self, guild_id: u64, track: String, error: String)
         -> Box<Future<Item = (), Error = ()>>;
 
     /// Tymethod called when a track is determined as being "stuck" in playing.
     ///
     /// Includes the threshold in milliseconds before a track is detected as
     /// being stuck.
-    fn track_stuck(&mut self, track: String, threshold_ms: i64)
+    fn track_stuck(&mut self, guild_id: u64, track: String, threshold_ms: i64)
         -> Box<Future<Item = (), Error = ()>>;
 }

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -349,6 +349,7 @@ fn handle_event(handler: Rc<RefCell<Box<EventHandler>>>, json: &Value, player_ma
             match handler.try_borrow_mut() {
                 Ok(mut handler) => {
                     Box::new(handler.track_end(
+                        guild_id,
                         track.to_owned(),
                         reason.to_owned(),
                     ).map(|_| None))
@@ -370,6 +371,7 @@ fn handle_event(handler: Rc<RefCell<Box<EventHandler>>>, json: &Value, player_ma
             match handler.try_borrow_mut() {
                 Ok(mut handler) => {
                     Box::new(handler.track_exception(
+                        guild_id,
                         track.to_owned(),
                         error.to_owned(),
                     ).map(|_| None))
@@ -389,6 +391,7 @@ fn handle_event(handler: Rc<RefCell<Box<EventHandler>>>, json: &Value, player_ma
             match handler.try_borrow_mut() {
                Ok(mut handler) => {
                     Box::new(handler.track_stuck(
+                        guild_id,
                         track.to_owned(),
                         threshold_ms,
                     ).map(|_| None))


### PR DESCRIPTION
make events usable again